### PR TITLE
Enable translation and add English and Polish translation files

### DIFF
--- a/custom_components/reqnet/binary_sensor.py
+++ b/custom_components/reqnet/binary_sensor.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 
 import logging
 
-from homeassistant.components.binary_sensor import BinarySensorEntity
+from homeassistant.components.binary_sensor import (
+    BinarySensorEntity,
+    BinarySensorEntityDescription,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -19,45 +22,58 @@ async def async_setup_entry(
     config_entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up Reqnet binary sensor platform."""
+    """Konfiguracja platformy czujników binarnych Reqnet."""
     coordinator: ReqnetDataCoordinator = hass.data[DOMAIN][config_entry.entry_id]
 
     binary_sensors = [
         # Indeks 0: Status urządzenia (1 - włączone, 0 - wyłączone)
-        ReqnetBinarySensor(coordinator, 0, "Rekuperator - Status urządzenia", "mdi:power", "mdi:power-off"),
+        ReqnetBinarySensor(
+            coordinator,
+            0,
+            BinarySensorEntityDescription(
+                key="device_status",
+                translation_key="device_status",
+                icon="mdi:power",
+            ),
+            "mdi:power",
+            "mdi:power-off",
+        ),
     ]
 
     async_add_entities(binary_sensors)
 
 
 class ReqnetBinarySensor(CoordinatorEntity, BinarySensorEntity):
-    """Representation of a Reqnet Binary Sensor."""
+    """Reprezentacja czujnika binarnego Reqnet."""
     _attr_has_entity_name = True
+
     def __init__(
         self,
         coordinator: ReqnetDataCoordinator,
         index: int,
-        name: str,
+        entity_description: BinarySensorEntityDescription,
         on_icon: str | None,
         off_icon: str | None,
     ) -> None:
-        """Initialize the binary sensor."""
+        """Inicjalizacja czujnika binarnego."""
         super().__init__(coordinator)
+        self.entity_description = entity_description
         self._index = index
-        self._name = name
         self._on_icon = on_icon
         self._off_icon = off_icon
 
-        self._attr_unique_id = f"{coordinator.mac_address.replace(':', '').lower()}_{name.lower().replace(' ', '_')}"
-        self._attr_name = name
-
+        self._attr_unique_id = f"{coordinator.mac_address.replace(':', '').lower()}_{entity_description.key}"
         # Powiąż encję z urządzeniem (rekuperatorem)
-        
-        #}
+        self._attr_device_info = {
+            "identifiers": {(DOMAIN, coordinator.mac_address)},
+            "name": f"Reqnet Recuperator ({coordinator.mac_address})",
+            "manufacturer": "Reqnet",
+            "model": "Recuperator",
+        }
 
     @property
     def is_on(self) -> bool | None:
-        """Return true if the binary sensor is on."""
+        """Zwraca true jeśli czujnik binarny jest włączony."""
         if self.coordinator.data is None or self._index >= len(self.coordinator.data):
             return None
         # Zakładamy, że 1 to True (on), a 0 to False (off)
@@ -65,7 +81,7 @@ class ReqnetBinarySensor(CoordinatorEntity, BinarySensorEntity):
 
     @property
     def icon(self):
-        """Return the icon of the binary sensor."""
+        """Zwraca ikonę czujnika binarnego."""
         if self.is_on:
             return self._on_icon
         return self._off_icon

--- a/custom_components/reqnet/binary_sensor.py
+++ b/custom_components/reqnet/binary_sensor.py
@@ -22,7 +22,7 @@ async def async_setup_entry(
     config_entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Konfiguracja platformy czujników binarnych Reqnet."""
+    """Set up Reqnet binary sensor platform."""
     coordinator: ReqnetDataCoordinator = hass.data[DOMAIN][config_entry.entry_id]
 
     binary_sensors = [
@@ -44,7 +44,7 @@ async def async_setup_entry(
 
 
 class ReqnetBinarySensor(CoordinatorEntity, BinarySensorEntity):
-    """Reprezentacja czujnika binarnego Reqnet."""
+    """Representation of a Reqnet Binary Sensor."""
     _attr_has_entity_name = True
 
     def __init__(
@@ -55,7 +55,7 @@ class ReqnetBinarySensor(CoordinatorEntity, BinarySensorEntity):
         on_icon: str | None,
         off_icon: str | None,
     ) -> None:
-        """Inicjalizacja czujnika binarnego."""
+        """Initialize the binary sensor."""
         super().__init__(coordinator)
         self.entity_description = entity_description
         self._index = index
@@ -73,7 +73,7 @@ class ReqnetBinarySensor(CoordinatorEntity, BinarySensorEntity):
 
     @property
     def is_on(self) -> bool | None:
-        """Zwraca true jeśli czujnik binarny jest włączony."""
+        """Return true if the binary sensor is on."""
         if self.coordinator.data is None or self._index >= len(self.coordinator.data):
             return None
         # Zakładamy, że 1 to True (on), a 0 to False (off)
@@ -81,7 +81,7 @@ class ReqnetBinarySensor(CoordinatorEntity, BinarySensorEntity):
 
     @property
     def icon(self):
-        """Zwraca ikonę czujnika binarnego."""
+        """Return the icon of the binary sensor."""
         if self.is_on:
             return self._on_icon
         return self._off_icon

--- a/custom_components/reqnet/button.py
+++ b/custom_components/reqnet/button.py
@@ -21,12 +21,12 @@ _LOGGER = logging.getLogger(__name__)
 BUTTON_DESCRIPTIONS = [
     ButtonEntityDescription(
         key="automatic_mode",
-        name="Reqnet Włącz tryb inteligentny",
+        translation_key="automatic_mode",
         icon="mdi:brain",
     ),
     ButtonEntityDescription(
         key="manual_mode",
-        name="Reqnet Włącz tryb ręczny",
+        translation_key="manual_mode",
         icon="mdi:hand-back-right",
     ),
 ]

--- a/custom_components/reqnet/sensor.py
+++ b/custom_components/reqnet/sensor.py
@@ -19,6 +19,7 @@ from homeassistant.const import (
     CONCENTRATION_PARTS_PER_MILLION,
     UnitOfPower,
     UnitOfPressure, # Dodane dla ciśnienia/oporu
+    UnitOfTime,
 )
 # Upewnij się, że DOMAIN i ReqnetDataCoordinator są poprawnie zdefiniowane/importowane
 from .const import DOMAIN # Zakładam, że DOMAIN jest zdefiniowany w .const
@@ -67,7 +68,7 @@ SENSOR_DEFINITIONS: list[tuple[int, str, str | None, str | None, SensorDeviceCla
     (72, "preheater_status", None, "mdi:radiator", None, None), # API Index 73 (0/1)
     (73, "antifreeze_system_status", None, "mdi:snowflake-melt", None, None), # API Index 74
     (74, "condensation_system_status", None, "mdi:water-boiler-alert", None, None), # API Index 75
-    (83, "filter_days_until_replacement", "dni", "mdi:air-filter", None, None), # API Index 84
+    (83, "filter_days_until_replacement", UnitOfTime.DAYS, "mdi:air-filter", None, None), # API Index 84
     (86, "mount_type", None, "mdi:tools", None, EntityCategory.DIAGNOSTIC), # API Index 87 (1-lewy, 2-prawy)
     (92, "overpressure_coefficient", PERCENTAGE, "mdi:arrow-expand-all", None, None), # API Index 93
 

--- a/custom_components/reqnet/sensor.py
+++ b/custom_components/reqnet/sensor.py
@@ -26,7 +26,8 @@ from .coordinator import ReqnetDataCoordinator # Zakładam, że koordynator jest
 
 _LOGGER = logging.getLogger(__name__)
 
-# Definicje sensorów: (index_python, translation_key, jednostka, ikona, klasa_urządzenia, kategoria_encji)
+# Definicje sensorów:
+# (index_python (API_Index - 1), translation_key, jednostka, ikona, klasa_urządzenia, kategoria_encji)
 SENSOR_DEFINITIONS: list[tuple[int, str, str | None, str | None, SensorDeviceClass | None, EntityCategory | None]] = [
     # --- Podstawowe odczyty ---
     (0, "device_status", None, "mdi:power", None, None), # API Index 1
@@ -77,14 +78,14 @@ SENSOR_DEFINITIONS: list[tuple[int, str, str | None, str | None, SensorDeviceCla
     (82, "extraction_fan_power", UnitOfPower.WATT, "mdi:lightning-bolt", SensorDeviceClass.POWER, None), # API Index 83
 
     # --- Ustawienia ---
-    (67, "comfort_temperature_setpoint", UnitOfTemperature.CELSIUS, "mdi:thermometer-box", SensorDeviceClass.TEMPERATURE, None),
-    (69, "co2_sensitivity", None, "mdi:molecule-co2", None, None),
-    (70, "higro_sensitivity", None, "mdi:water-opacity", None, None),
+    (67, "comfort_temperature_setpoint", UnitOfTemperature.CELSIUS, "mdi:thermostat-box", SensorDeviceClass.TEMPERATURE, None), # API Index 68
+    (69, "co2_sensitivity", None, "mdi:molecule-co2", None, None), # API Index 70 (jednostka nieznana z API)
+    (70, "higro_sensitivity", None, "mdi:water-opacity", None, None), # API Index 71 (jednostka nieznana z API)
 
     # --- Wersje oprogramowania (diagnostyczne) ---
-    (90, "firmware_version_major", None, "mdi:chip", None, EntityCategory.DIAGNOSTIC),
-    (91, "firmware_version_build", None, "mdi:chip", None, EntityCategory.DIAGNOSTIC),
-    (93, "firmware_version_wifi", None, "mdi:wifi", None, EntityCategory.DIAGNOSTIC),
+    (90, "firmware_version_major", None, "mdi:chip", None, EntityCategory.DIAGNOSTIC), # API Index 91
+    (91, "firmware_version_build", None, "mdi:chip", None, EntityCategory.DIAGNOSTIC), # API Index 92
+    (93, "firmware_version_wifi", None, "mdi:wifi", None, EntityCategory.DIAGNOSTIC), # API Index 94
 
     # --- Współczynniki wydajności dla funkcji (opcjonalne) ---
     # (16, "Wydajność Szybkie grzanie", PERCENTAGE, "mdi:fire", None, None), # API Index 17
@@ -131,7 +132,7 @@ class ReqnetSensor(CoordinatorEntity[ReqnetDataCoordinator], SensorEntity):
         unit: str | None,
         icon: str | None,
         device_class: SensorDeviceClass | None = None,
-        entity_category: EntityCategory | None = None,
+        entity_category: EntityCategory | None = None, # POPRAWIONE TYPOWANIE
     ) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator)
@@ -179,6 +180,7 @@ class ReqnetSensor(CoordinatorEntity[ReqnetDataCoordinator], SensorEntity):
             return None # Zgodnie z dokumentacją HA, powinno zwracać None lub STATE_UNAVAILABLE
 
         value = self.coordinator.data[self._index]
+        self._attr_translation_placeholders = {}
 
         # Mapowanie wartości dla specyficznych sensorów
         # API Index 1 (Python index 0): Status urządzenia
@@ -196,12 +198,18 @@ class ReqnetSensor(CoordinatorEntity[ReqnetDataCoordinator], SensorEntity):
                 4: "ventilation", 5: "purification", 6: "fireplace",
                 8: "manual_mode", 9: "intelligent_mode", 10: "efficiency_measurement_mode",
             }
-            return modes.get(value, "unknown_mode")
+            if value in modes:
+                return modes[value]
+            self._attr_translation_placeholders = {"value": str(value)}
+            return "unknown_mode"
 
         # API Index 14 (Python index 13): Status funkcji równoległej (grzanie/chłodzenie)
         if self._index == 13:
             statuses = {0: "inactive", 1: "heating", 2: "cooling"}
-            return statuses.get(value, "unknown_status")
+            if value in statuses:
+                return statuses[value]
+            self._attr_translation_placeholders = {"value": str(value)}
+            return "unknown_status"
 
         # API Index 40 (Python index 39): Wartość ByPassu
         if self._index == 39:
@@ -209,7 +217,10 @@ class ReqnetSensor(CoordinatorEntity[ReqnetDataCoordinator], SensorEntity):
                 0: "closed_manual", 1: "open_manual",
                 2: "closed_auto", 3: "open_auto",
             }
-            return bypass_status.get(value, "unknown_status")
+            if value in bypass_status:
+                return bypass_status[value]
+            self._attr_translation_placeholders = {"value": str(value)}
+            return "unknown_status"
 
         # API Index 72 (Python index 71): Detekcja wilgotności
         if self._index == 71:
@@ -222,6 +233,9 @@ class ReqnetSensor(CoordinatorEntity[ReqnetDataCoordinator], SensorEntity):
         # API Index 87 (Python index 86): Typ montażu
         if self._index == 86:
             types = {1: "left", 2: "right"}
-            return types.get(value, "unknown")
+            if value in types:
+                return types[value]
+            self._attr_translation_placeholders = {"value": str(value)}
+            return "unknown"
 
         return value

--- a/custom_components/reqnet/sensor.py
+++ b/custom_components/reqnet/sensor.py
@@ -26,67 +26,65 @@ from .coordinator import ReqnetDataCoordinator # Zakładam, że koordynator jest
 
 _LOGGER = logging.getLogger(__name__)
 
-# Definicje sensorów:
-# (index_python (API_Index - 1), nazwa_przyrostka, jednostka, ikona, klasa_urządzenia, kategoria_encji)
-SENSOR_DEFINITIONS: list[tuple[int, str, str | None, str | None, SensorDeviceClass | None, str | None]] = [
+# Definicje sensorów: (index_python, translation_key, jednostka, ikona, klasa_urządzenia, kategoria_encji)
+SENSOR_DEFINITIONS: list[tuple[int, str, str | None, str | None, SensorDeviceClass | None, EntityCategory | None]] = [
     # --- Podstawowe odczyty ---
-    (0, "Status urządzenia", None, "mdi:power", None, None), # API Index 1
-    (1, "Maksymalna wartość nawiewu", "m³/h", "mdi:fan-plus", None, None), # API Index 2
-    (2, "Aktualna temperatura", UnitOfTemperature.CELSIUS, "mdi:thermometer", SensorDeviceClass.TEMPERATURE, None), # API Index 3
-    (3, "Aktualna wartość nawiewu", "m³/h", "mdi:fan", None, None), # API Index 4
-    (4, "Aktualna wartość wyciągu", "m³/h", "mdi:fan-off", None, None), # API Index 5
-    (5, "Nawiew tryb ręczny", "m³/h", "mdi:fan-settings", None, None), # API Index 6
-    (6, "Wyciąg tryb ręczny", "m³/h", "mdi:fan-settings", None, None), # API Index 7
-    (7, "Wilgotność", PERCENTAGE, "mdi:water-percent", SensorDeviceClass.HUMIDITY, None), # API Index 8
-    (8, "Poziom CO2", CONCENTRATION_PARTS_PER_MILLION, "mdi:molecule-co2", "carbon_dioxide", None), # API Index 9
-    (9, "Status harmonogramu", None, "mdi:calendar-clock", None, None), # API Index 10 (0/1)
-    (10, "Tryb pracy", None, "mdi:cog-outline", None, None), # API Index 11 (mapowane wartości)
-    (13, "Status grzanie/chłodzenie", None, "mdi:thermostat", None, None), # API Index 14 (0/1/2)
-    (15, "Model urządzenia", None, "mdi:information-outline", None, EntityCategory.DIAGNOSTIC), # API Index 16
+    (0, "device_status", None, "mdi:power", None, None), # API Index 1
+    (1, "max_supply_flow", "m³/h", "mdi:fan-plus", None, None), # API Index 2
+    (2, "current_temperature", UnitOfTemperature.CELSIUS, "mdi:thermometer", SensorDeviceClass.TEMPERATURE, None), # API Index 3
+    (3, "current_supply_flow", "m³/h", "mdi:fan", None, None), # API Index 4
+    (4, "current_extraction_flow", "m³/h", "mdi:fan-off", None, None), # API Index 5
+    (5, "supply_manual_mode", "m³/h", "mdi:fan-settings", None, None), # API Index 6
+    (6, "extraction_manual_mode", "m³/h", "mdi:fan-settings", None, None), # API Index 7
+    (7, "humidity", PERCENTAGE, "mdi:water-percent", SensorDeviceClass.HUMIDITY, None), # API Index 8
+    (8, "co2_level", CONCENTRATION_PARTS_PER_MILLION, "mdi:molecule-co2", "carbon_dioxide", None), # API Index 9
+    (9, "schedule_status", None, "mdi:calendar-clock", None, None), # API Index 10 (0/1)
+    (10, "operation_mode", None, "mdi:cog-outline", None, None), # API Index 11 (mapowane wartości)
+    (13, "heating_cooling_status", None, "mdi:thermostat", None, None), # API Index 14 (0/1/2)
+    (15, "device_model", None, "mdi:information-outline", None, EntityCategory.DIAGNOSTIC), # API Index 16
 
     # --- Temperatury szczegółowe ---
-    (55, "Temperatura na czerpni", UnitOfTemperature.CELSIUS, "mdi:export", SensorDeviceClass.TEMPERATURE, None), # API Index 56
-    (56, "Temperatura na wyrzutni", UnitOfTemperature.CELSIUS, "mdi:import", SensorDeviceClass.TEMPERATURE, None), # API Index 57
-    (57, "Temperatura nawiewu", UnitOfTemperature.CELSIUS, "mdi:coolant-temperature", SensorDeviceClass.TEMPERATURE, None), # API Index 58
-    (58, "Temperatura wyciągu", UnitOfTemperature.CELSIUS, "mdi:coolant-temperature", SensorDeviceClass.TEMPERATURE, None), # API Index 59
-    (59, "Temperatura za nagrzewnicą/chłodnicą", UnitOfTemperature.CELSIUS, "mdi:thermometer-lines", SensorDeviceClass.TEMPERATURE, None), # API Index 60
-    (60, "Temperatura GWC", UnitOfTemperature.CELSIUS, "mdi:sun-thermometer-outline", SensorDeviceClass.TEMPERATURE, None), # API Index 61
-    (61, "Temperatura w pomieszczeniu", UnitOfTemperature.CELSIUS, "mdi:home-thermometer-outline", SensorDeviceClass.TEMPERATURE, None), # API Index 62
-    (62, "Temperatura dodatkowego czujnika", UnitOfTemperature.CELSIUS, "mdi:thermometer-alert", SensorDeviceClass.TEMPERATURE, None), # API Index 63
+    (55, "intake_temperature", UnitOfTemperature.CELSIUS, "mdi:export", SensorDeviceClass.TEMPERATURE, None), # API Index 56
+    (56, "exhaust_duct_temperature", UnitOfTemperature.CELSIUS, "mdi:import", SensorDeviceClass.TEMPERATURE, None), # API Index 57
+    (57, "supply_temperature", UnitOfTemperature.CELSIUS, "mdi:coolant-temperature", SensorDeviceClass.TEMPERATURE, None), # API Index 58
+    (58, "extraction_temperature", UnitOfTemperature.CELSIUS, "mdi:coolant-temperature", SensorDeviceClass.TEMPERATURE, None), # API Index 59
+    (59, "temperature_after_heater_cooler", UnitOfTemperature.CELSIUS, "mdi:thermometer-lines", SensorDeviceClass.TEMPERATURE, None), # API Index 60
+    (60, "gwc_temperature", UnitOfTemperature.CELSIUS, "mdi:sun-thermometer-outline", SensorDeviceClass.TEMPERATURE, None), # API Index 61
+    (61, "room_temperature", UnitOfTemperature.CELSIUS, "mdi:home-thermometer-outline", SensorDeviceClass.TEMPERATURE, None), # API Index 62
+    (62, "additional_sensor_temperature", UnitOfTemperature.CELSIUS, "mdi:thermometer-alert", SensorDeviceClass.TEMPERATURE, None), # API Index 63
 
     # --- Ciśnienia/Opory ---
-    (63, "Opór ciągu nawiewnego", UnitOfPressure.PA, "mdi:gauge-low", SensorDeviceClass.PRESSURE, None), # API Index 64
-    (64, "Opór ciągu wywiewnego", UnitOfPressure.PA, "mdi:gauge-low", SensorDeviceClass.PRESSURE, None), # API Index 65
-    (75, "Ciśnienie nawiew", UnitOfPressure.PA, "mdi:arrow-down-bold-pressure-outline", SensorDeviceClass.PRESSURE, None), # API Index 76 (zakładam Pa)
-    (76, "Ciśnienie wyciąg", UnitOfPressure.PA, "mdi:arrow-up-bold-pressure-outline", SensorDeviceClass.PRESSURE, None), # API Index 77 (zakładam Pa)
-
+    (63, "supply_duct_resistance", UnitOfPressure.PA, "mdi:gauge-low", SensorDeviceClass.PRESSURE, None), # API Index 64
+    (64, "extraction_duct_resistance", UnitOfPressure.PA, "mdi:gauge-low", SensorDeviceClass.PRESSURE, None), # API Index 65
+    (75, "supply_pressure", UnitOfPressure.PA, "mdi:arrow-down-bold-pressure-outline", SensorDeviceClass.PRESSURE, None),  # API Index 76 (zakładam Pa)
+    (76, "extraction_pressure", UnitOfPressure.PA, "mdi:arrow-up-bold-pressure-outline", SensorDeviceClass.PRESSURE, None), # API Index 77 (zakładam Pa)
     # --- Statusy i inne ---
-    (39, "Status By-passu", None, "mdi:compare-horizontal", None, None), # API Index 40 (mapowane wartości)
-    (40, "Kod błędu", None, "mdi:alert-circle-outline", None, EntityCategory.DIAGNOSTIC), # API Index 41
-    (41, "Kod komunikatu", None, "mdi:information-outline", None, EntityCategory.DIAGNOSTIC), # API Index 42
-    (71, "Detekcja wilgotności", None, "mdi:water-check-outline", None, None), # API Index 72 (0/1)
-    (72, "Status nagrzewnicy wstępnej", None, "mdi:radiator", None, None), # API Index 73 (0/1)
-    (73, "Status systemu antyzamrożeniowego", None, "mdi:snowflake-melt", None, None), # API Index 74
-    (74, "Status systemu przeciwwykropleniowego", None, "mdi:water-boiler-alert", None, None), # API Index 75
-    (83, "Dni do wymiany filtra", "dni", "mdi:air-filter", None, None), # API Index 84
-    (86, "Typ montażu", None, "mdi:tools", None, EntityCategory.DIAGNOSTIC), # API Index 87 (1-lewy, 2-prawy)
-    (92, "Współczynnik nadciśnienia", PERCENTAGE, "mdi:arrow-expand-all", None, None), # API Index 93
+    (39, "bypass_status", None, "mdi:compare-horizontal", None, None), # API Index 40 (mapowane wartości)
+    (40, "error_code", None, "mdi:alert-circle-outline", None, EntityCategory.DIAGNOSTIC), # API Index 41
+    (41, "message_code", None, "mdi:information-outline", None, EntityCategory.DIAGNOSTIC), # API Index 42
+    (71, "humidity_detection", None, "mdi:water-check-outline", None, None), # API Index 72 (0/1)
+    (72, "preheater_status", None, "mdi:radiator", None, None), # API Index 73 (0/1)
+    (73, "antifreeze_system_status", None, "mdi:snowflake-melt", None, None), # API Index 74
+    (74, "condensation_system_status", None, "mdi:water-boiler-alert", None, None), # API Index 75
+    (83, "filter_days_until_replacement", "dni", "mdi:air-filter", None, None), # API Index 84
+    (86, "mount_type", None, "mdi:tools", None, EntityCategory.DIAGNOSTIC), # API Index 87 (1-lewy, 2-prawy)
+    (92, "overpressure_coefficient", PERCENTAGE, "mdi:arrow-expand-all", None, None), # API Index 93
 
     # --- Wentylatory ---
-    (65, "Prędkość wentylatora nawiew", PERCENTAGE, "mdi:fan-chevron-up", None, None), # API Index 66
-    (66, "Prędkość wentylatora wyciąg", PERCENTAGE, "mdi:fan-chevron-down", None, None), # API Index 67
-    (81, "Moc wentylatora nawiewnego", UnitOfPower.WATT, "mdi:lightning-bolt", SensorDeviceClass.POWER, None), # API Index 82
-    (82, "Moc wentylatora wywiewnego", UnitOfPower.WATT, "mdi:lightning-bolt", SensorDeviceClass.POWER, None), # API Index 83
+    (65, "supply_fan_speed", PERCENTAGE, "mdi:fan-chevron-up", None, None), # API Index 66
+    (66, "extraction_fan_speed", PERCENTAGE, "mdi:fan-chevron-down", None, None), # API Index 67
+    (81, "supply_fan_power", UnitOfPower.WATT, "mdi:lightning-bolt", SensorDeviceClass.POWER, None), # API Index 82
+    (82, "extraction_fan_power", UnitOfPower.WATT, "mdi:lightning-bolt", SensorDeviceClass.POWER, None), # API Index 83
 
     # --- Ustawienia ---
-    (67, "Ustawiona temperatura komfortu", UnitOfTemperature.CELSIUS, "mdi:thermostat-box", SensorDeviceClass.TEMPERATURE, None), # API Index 68
-    (69, "Aktualna czułość CO2", None, "mdi:molecule-co2", None, None), # API Index 70 (jednostka nieznana z API)
-    (70, "Aktualna czułość HIGRO", None, "mdi:water-opacity", None, None), # API Index 71 (jednostka nieznana z API)
+    (67, "comfort_temperature_setpoint", UnitOfTemperature.CELSIUS, "mdi:thermometer-box", SensorDeviceClass.TEMPERATURE, None),
+    (69, "co2_sensitivity", None, "mdi:molecule-co2", None, None),
+    (70, "higro_sensitivity", None, "mdi:water-opacity", None, None),
 
     # --- Wersje oprogramowania (diagnostyczne) ---
-    (90, "Wersja firmware (major)", None, "mdi:chip", None, EntityCategory.DIAGNOSTIC), # API Index 91
-    (91, "Wersja firmware (build)", None, "mdi:chip", None, EntityCategory.DIAGNOSTIC), # API Index 92
-    (93, "Wersja firmware WiFi", None, "mdi:wifi", None, EntityCategory.DIAGNOSTIC), # API Index 94
+    (90, "firmware_version_major", None, "mdi:chip", None, EntityCategory.DIAGNOSTIC),
+    (91, "firmware_version_build", None, "mdi:chip", None, EntityCategory.DIAGNOSTIC),
+    (93, "firmware_version_wifi", None, "mdi:wifi", None, EntityCategory.DIAGNOSTIC),
 
     # --- Współczynniki wydajności dla funkcji (opcjonalne) ---
     # (16, "Wydajność Szybkie grzanie", PERCENTAGE, "mdi:fire", None, None), # API Index 17
@@ -102,16 +100,16 @@ async def async_setup_entry(
     config_entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up Reqnet sensor platform."""
+    """Konfiguracja platformy sensorów Reqnet."""
     coordinator: ReqnetDataCoordinator = hass.data[DOMAIN][config_entry.entry_id]
 
     entities_to_add = []
-    for index, name_suffix, unit, icon, dev_class, entity_cat in SENSOR_DEFINITIONS:
+    for index, translation_key, unit, icon, dev_class, entity_cat in SENSOR_DEFINITIONS:
         entities_to_add.append(
             ReqnetSensor(
                 coordinator=coordinator,
                 index=index,
-                name_suffix=name_suffix,
+                translation_key=translation_key,
                 unit=unit,
                 icon=icon,
                 device_class=dev_class,
@@ -129,25 +127,23 @@ class ReqnetSensor(CoordinatorEntity[ReqnetDataCoordinator], SensorEntity):
         self,
         coordinator: ReqnetDataCoordinator,
         index: int,
-        name_suffix: str,
+        translation_key: str,
         unit: str | None,
         icon: str | None,
         device_class: SensorDeviceClass | None = None,
-        entity_category: EntityCategory | None = None, # POPRAWIONE TYPOWANIE
+        entity_category: EntityCategory | None = None,
     ) -> None:
-        """Initialize the sensor."""
+        """Inicjalizacja sensora."""
         super().__init__(coordinator)
         self._index = index
 
-        display_name = f"Reqnet {name_suffix}"
-
         self.entity_description = SensorEntityDescription(
             key=f"value_{self._index}",
-            name=display_name,
+            translation_key=translation_key,
             icon=icon,
             native_unit_of_measurement=unit,
             device_class=device_class,
-            entity_category=entity_category, # Tutaj zostanie przekazana poprawna instancja EntityCategory lub None
+            entity_category=entity_category,
         )
 
         # Unikalne ID dla encji
@@ -171,7 +167,7 @@ class ReqnetSensor(CoordinatorEntity[ReqnetDataCoordinator], SensorEntity):
 
     @property
     def native_value(self):
-        """Return the state of the sensor."""
+        """Zwraca stan sensora."""
         if (
             self.coordinator.data is None
             or not isinstance(self.coordinator.data, list)
@@ -184,48 +180,48 @@ class ReqnetSensor(CoordinatorEntity[ReqnetDataCoordinator], SensorEntity):
 
         value = self.coordinator.data[self._index]
 
-        # Mapowanie wartości dla specyficznych sensorów
+        # Mapowanie wartości na klucze tłumaczeń stanu
         # API Index 1 (Python index 0): Status urządzenia
         if self._index == 0:
-            return "Włączone" if value == 1 else "Wyłączone"
-        
+            return "on" if value == 1 else "off"
+
         # API Index 10 (Python index 9): Status harmonogramu
         if self._index == 9:
-            return "Aktywny" if value == 1 else "Nieaktywny"
+            return "active" if value == 1 else "inactive"
 
         # API Index 11 (Python index 10): Tryb pracy
         if self._index == 10:
             modes = {
-                1: "Szybkie grzanie", 2: "Szybkie chłodzenie", 3: "Urlop",
-                4: "Przewietrzanie", 5: "Oczyszczanie", 6: "Kominek",
-                8: "Tryb ręczny", 9: "Tryb inteligentny", 10: "Tryb pomiaru wydajności",
+                1: "fast_heating", 2: "fast_cooling", 3: "vacation",
+                4: "ventilation", 5: "purification", 6: "fireplace",
+                8: "manual_mode", 9: "intelligent_mode", 10: "efficiency_measurement_mode",
             }
-            return modes.get(value, f"Nieznany tryb ({value})")
+            return modes.get(value, "unknown_mode")
 
         # API Index 14 (Python index 13): Status funkcji równoległej (grzanie/chłodzenie)
         if self._index == 13:
-            statuses = {0: "Nieaktywna", 1: "Grzanie", 2: "Chłodzenie"}
-            return statuses.get(value, f"Nieznany status ({value})")
+            statuses = {0: "inactive", 1: "heating", 2: "cooling"}
+            return statuses.get(value, "unknown_status")
 
         # API Index 40 (Python index 39): Wartość ByPassu
         if self._index == 39:
             bypass_status = {
-                0: "Zamknięty (ręcznie)", 1: "Otwarty (ręcznie)",
-                2: "Zamknięty (auto)", 3: "Otwarty (auto)",
+                0: "closed_manual", 1: "open_manual",
+                2: "closed_auto", 3: "open_auto",
             }
-            return bypass_status.get(value, f"Nieznany status ({value})")
+            return bypass_status.get(value, "unknown_status")
 
         # API Index 72 (Python index 71): Detekcja wilgotności
         if self._index == 71:
-            return "Aktywna" if value == 1 else "Nieaktywna"
+            return "active" if value == 1 else "inactive"
 
         # API Index 73 (Python index 72): Status nagrzewnicy wstępnej
         if self._index == 72:
-            return "Aktywna" if value == 1 else "Nieaktywna"
+            return "active" if value == 1 else "inactive"
 
         # API Index 87 (Python index 86): Typ montażu
         if self._index == 86:
-            types = {1: "Lewy", 2: "Prawy"}
-            return types.get(value, f"Nieznany ({value})")
+            types = {1: "left", 2: "right"}
+            return types.get(value, "unknown")
 
         return value

--- a/custom_components/reqnet/sensor.py
+++ b/custom_components/reqnet/sensor.py
@@ -20,6 +20,7 @@ from homeassistant.const import (
     UnitOfPower,
     UnitOfPressure, # Dodane dla ciśnienia/oporu
     UnitOfTime,
+    UnitOfVolumeFlowRate,
 )
 # Upewnij się, że DOMAIN i ReqnetDataCoordinator są poprawnie zdefiniowane/importowane
 from .const import DOMAIN # Zakładam, że DOMAIN jest zdefiniowany w .const
@@ -32,12 +33,12 @@ _LOGGER = logging.getLogger(__name__)
 SENSOR_DEFINITIONS: list[tuple[int, str, str | None, str | None, SensorDeviceClass | None, EntityCategory | None]] = [
     # --- Podstawowe odczyty ---
     (0, "device_status", None, "mdi:power", None, None), # API Index 1
-    (1, "max_supply_flow", "m³/h", "mdi:fan-plus", None, None), # API Index 2
+    (1, "max_supply_flow", UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR, "mdi:fan-plus", None, None), # API Index 2
     (2, "current_temperature", UnitOfTemperature.CELSIUS, "mdi:thermometer", SensorDeviceClass.TEMPERATURE, None), # API Index 3
-    (3, "current_supply_flow", "m³/h", "mdi:fan", None, None), # API Index 4
-    (4, "current_extraction_flow", "m³/h", "mdi:fan-off", None, None), # API Index 5
-    (5, "supply_manual_mode", "m³/h", "mdi:fan-settings", None, None), # API Index 6
-    (6, "extraction_manual_mode", "m³/h", "mdi:fan-settings", None, None), # API Index 7
+    (3, "current_supply_flow", UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR, "mdi:fan", None, None), # API Index 4
+    (4, "current_extraction_flow", UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR, "mdi:fan-off", None, None), # API Index 5
+    (5, "supply_manual_mode", UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR, "mdi:fan-settings", None, None), # API Index 6
+    (6, "extraction_manual_mode", UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR, "mdi:fan-settings", None, None), # API Index 7
     (7, "humidity", PERCENTAGE, "mdi:water-percent", SensorDeviceClass.HUMIDITY, None), # API Index 8
     (8, "co2_level", CONCENTRATION_PARTS_PER_MILLION, "mdi:molecule-co2", "carbon_dioxide", None), # API Index 9
     (9, "schedule_status", None, "mdi:calendar-clock", None, None), # API Index 10 (0/1)

--- a/custom_components/reqnet/sensor.py
+++ b/custom_components/reqnet/sensor.py
@@ -100,7 +100,7 @@ async def async_setup_entry(
     config_entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Konfiguracja platformy sensorów Reqnet."""
+    """Set up Reqnet sensor platform."""
     coordinator: ReqnetDataCoordinator = hass.data[DOMAIN][config_entry.entry_id]
 
     entities_to_add = []
@@ -133,7 +133,7 @@ class ReqnetSensor(CoordinatorEntity[ReqnetDataCoordinator], SensorEntity):
         device_class: SensorDeviceClass | None = None,
         entity_category: EntityCategory | None = None,
     ) -> None:
-        """Inicjalizacja sensora."""
+        """Initialize the sensor."""
         super().__init__(coordinator)
         self._index = index
 
@@ -167,7 +167,7 @@ class ReqnetSensor(CoordinatorEntity[ReqnetDataCoordinator], SensorEntity):
 
     @property
     def native_value(self):
-        """Zwraca stan sensora."""
+        """Return the state of the sensor."""
         if (
             self.coordinator.data is None
             or not isinstance(self.coordinator.data, list)
@@ -180,7 +180,7 @@ class ReqnetSensor(CoordinatorEntity[ReqnetDataCoordinator], SensorEntity):
 
         value = self.coordinator.data[self._index]
 
-        # Mapowanie wartości na klucze tłumaczeń stanu
+        # Mapowanie wartości dla specyficznych sensorów
         # API Index 1 (Python index 0): Status urządzenia
         if self._index == 0:
             return "on" if value == 1 else "off"

--- a/custom_components/reqnet/translations/en.json
+++ b/custom_components/reqnet/translations/en.json
@@ -44,7 +44,7 @@
           "manual_mode": "Manual mode",
           "intelligent_mode": "Intelligent mode",
           "efficiency_measurement_mode": "Efficiency measurement mode",
-          "unknown_mode": "Unknown mode"
+          "unknown_mode": "Unknown mode ({value})"
         }
       },
       "heating_cooling_status": {
@@ -53,7 +53,7 @@
           "inactive": "Inactive",
           "heating": "Heating",
           "cooling": "Cooling",
-          "unknown_status": "Unknown status"
+          "unknown_status": "Unknown status ({value})"
         }
       },
       "device_model": { "name": "Device model" },
@@ -76,7 +76,7 @@
           "open_manual": "Open (manual)",
           "closed_auto": "Closed (auto)",
           "open_auto": "Open (auto)",
-          "unknown_status": "Unknown status"
+          "unknown_status": "Unknown status ({value})"
         }
       },
       "error_code": { "name": "Error code" },
@@ -103,7 +103,7 @@
         "state": {
           "left": "Left",
           "right": "Right",
-          "unknown": "Unknown"
+          "unknown": "Unknown ({value})"
         }
       },
       "overpressure_coefficient": { "name": "Overpressure coefficient" },

--- a/custom_components/reqnet/translations/en.json
+++ b/custom_components/reqnet/translations/en.json
@@ -24,7 +24,7 @@
       "supply_manual_mode": { "name": "Supply manual mode" },
       "extraction_manual_mode": { "name": "Extraction manual mode" },
       "humidity": { "name": "Air humidity" },
-      "co2_level": { "name": "CO<sub>2</sub> level" },
+      "co2_level": { "name": "CO₂ level" },
       "schedule_status": {
         "name": "Schedule status",
         "state": {
@@ -112,7 +112,7 @@
       "supply_fan_power": { "name": "Supply fan power" },
       "extraction_fan_power": { "name": "Extraction fan power" },
       "comfort_temperature_setpoint": { "name": "Comfort temperature setpoint" },
-      "co2_sensitivity": { "name": "CO2 sensitivity" },
+      "co2_sensitivity": { "name": "CO₂ sensitivity" },
       "higro_sensitivity": { "name": "HIGRO sensitivity" },
       "firmware_version_major": { "name": "Firmware version (major)" },
       "firmware_version_build": { "name": "Firmware version (build)" },

--- a/custom_components/reqnet/translations/en.json
+++ b/custom_components/reqnet/translations/en.json
@@ -1,0 +1,149 @@
+{
+  "config": {
+    "error": {
+      "cannot_connect": "Unable to connect to the device. Please check the host and try again.",
+      "invalid_json": "Invalid response from device (invalid JSON).",
+      "invalid_response": "Unexpected response structure from device.",
+      "http_error": "HTTP error occurred while communicating with the device.",
+      "unknown": "An unexpected error occurred."
+    }
+  },
+  "entity": {
+    "sensor": {
+      "device_status": {
+        "name": "Device status",
+        "state": {
+          "on": "On",
+          "off": "Off"
+        }
+      },
+      "max_supply_flow": { "name": "Maximum supply flow" },
+      "current_temperature": { "name": "Current temperature" },
+      "current_supply_flow": { "name": "Current supply flow" },
+      "current_extraction_flow": { "name": "Current extraction flow" },
+      "supply_manual_mode": { "name": "Supply manual mode" },
+      "extraction_manual_mode": { "name": "Extraction manual mode" },
+      "humidity": { "name": "Humidity" },
+      "co2_level": { "name": "CO2 level" },
+      "schedule_status": {
+        "name": "Schedule status",
+        "state": {
+          "active": "Active",
+          "inactive": "Inactive"
+        }
+      },
+      "operation_mode": {
+        "name": "Operation mode",
+        "state": {
+          "fast_heating": "Fast heating",
+          "fast_cooling": "Fast cooling",
+          "vacation": "Vacation",
+          "ventilation": "Ventilation",
+          "purification": "Purification",
+          "fireplace": "Fireplace",
+          "manual_mode": "Manual mode",
+          "intelligent_mode": "Intelligent mode",
+          "efficiency_measurement_mode": "Efficiency measurement mode",
+          "unknown_mode": "Unknown mode"
+        }
+      },
+      "heating_cooling_status": {
+        "name": "Heating/cooling status",
+        "state": {
+          "inactive": "Inactive",
+          "heating": "Heating",
+          "cooling": "Cooling",
+          "unknown_status": "Unknown status"
+        }
+      },
+      "device_model": { "name": "Device model" },
+      "intake_temperature": { "name": "Intake temperature" },
+      "exhaust_duct_temperature": { "name": "Exhaust duct temperature" },
+      "supply_temperature": { "name": "Supply temperature" },
+      "extraction_temperature": { "name": "Extraction temperature" },
+      "temperature_after_heater_cooler": { "name": "Temperature after heater/cooler" },
+      "gwc_temperature": { "name": "Ground heat exchanger temperature" },
+      "room_temperature": { "name": "Room temperature" },
+      "additional_sensor_temperature": { "name": "Additional sensor temperature" },
+      "supply_duct_resistance": { "name": "Supply duct resistance" },
+      "extraction_duct_resistance": { "name": "Extraction duct resistance" },
+      "supply_pressure": { "name": "Supply pressure" },
+      "extraction_pressure": { "name": "Extraction pressure" },
+      "bypass_status": {
+        "name": "Bypass status",
+        "state": {
+          "closed_manual": "Closed (manual)",
+          "open_manual": "Open (manual)",
+          "closed_auto": "Closed (auto)",
+          "open_auto": "Open (auto)",
+          "unknown_status": "Unknown status"
+        }
+      },
+      "error_code": { "name": "Error code" },
+      "message_code": { "name": "Message code" },
+      "humidity_detection": {
+        "name": "Humidity detection",
+        "state": {
+          "active": "Active",
+          "inactive": "Inactive"
+        }
+      },
+      "preheater_status": {
+        "name": "Preheater status",
+        "state": {
+          "active": "Active",
+          "inactive": "Inactive"
+        }
+      },
+      "antifreeze_system_status": { "name": "Antifreeze system status" },
+      "condensation_system_status": { "name": "Condensation system status" },
+      "filter_days_until_replacement": { "name": "Days until filter replacement" },
+      "mount_type": {
+        "name": "Mount type",
+        "state": {
+          "left": "Left",
+          "right": "Right",
+          "unknown": "Unknown"
+        }
+      },
+      "overpressure_coefficient": { "name": "Overpressure coefficient" },
+      "supply_fan_speed": { "name": "Supply fan speed" },
+      "extraction_fan_speed": { "name": "Extraction fan speed" },
+      "supply_fan_power": { "name": "Supply fan power" },
+      "extraction_fan_power": { "name": "Extraction fan power" },
+      "comfort_temperature_setpoint": { "name": "Comfort temperature setpoint" },
+      "co2_sensitivity": { "name": "CO2 sensitivity" },
+      "higro_sensitivity": { "name": "HIGRO sensitivity" },
+      "firmware_version_major": { "name": "Firmware version (major)" },
+      "firmware_version_build": { "name": "Firmware version (build)" },
+      "firmware_version_wifi": { "name": "WiFi firmware version" }
+    },
+    "button": {
+      "automatic_mode": { "name": "Enable intelligent mode" },
+      "manual_mode": { "name": "Enable manual mode" }
+    },
+    "binary_sensor": {
+      "device_status": { "name": "Recuperator - Device status" }
+    }
+  },
+  "services": {
+    "set_manual_mode": {
+      "name": "Set manual mode",
+      "description": "Sets manual mode with specified supply and extraction values",
+      "fields": {
+        "device_id": {
+          "name": "Device ID",
+          "description": "Reqnet device ID (MAC address)"
+        },
+        "airflow_value": {
+          "name": "Supply value",
+          "description": "Desired supply value (m³/h)"
+        },
+        "air_extraction_value": {
+          "name": "Extraction value",
+          "description": "Desired extraction value (m³/h)"
+        }
+      }
+    }
+  }
+}

--- a/custom_components/reqnet/translations/en.json
+++ b/custom_components/reqnet/translations/en.json
@@ -18,13 +18,13 @@
         }
       },
       "max_supply_flow": { "name": "Maximum supply flow" },
-      "current_temperature": { "name": "Current temperature" },
+      "current_temperature": { "name": "Supply temperature" },
       "current_supply_flow": { "name": "Current supply flow" },
       "current_extraction_flow": { "name": "Current extraction flow" },
       "supply_manual_mode": { "name": "Supply manual mode" },
       "extraction_manual_mode": { "name": "Extraction manual mode" },
-      "humidity": { "name": "Humidity" },
-      "co2_level": { "name": "CO2 level" },
+      "humidity": { "name": "Air humidity" },
+      "co2_level": { "name": "CO<sub>2</sub> level" },
       "schedule_status": {
         "name": "Schedule status",
         "state": {
@@ -37,9 +37,9 @@
         "state": {
           "fast_heating": "Fast heating",
           "fast_cooling": "Fast cooling",
-          "vacation": "Vacation",
+          "vacation": "Holiday",
           "ventilation": "Ventilation",
-          "purification": "Purification",
+          "purification": "Cleansing",
           "fireplace": "Fireplace",
           "manual_mode": "Manual mode",
           "intelligent_mode": "Intelligent mode",
@@ -57,10 +57,10 @@
         }
       },
       "device_model": { "name": "Device model" },
-      "intake_temperature": { "name": "Intake temperature" },
-      "exhaust_duct_temperature": { "name": "Exhaust duct temperature" },
-      "supply_temperature": { "name": "Supply temperature" },
-      "extraction_temperature": { "name": "Extraction temperature" },
+      "intake_temperature": { "name": "Outdoor" },
+      "exhaust_duct_temperature": { "name": "Exhaust" },
+      "supply_temperature": { "name": "Supply" },
+      "extraction_temperature": { "name": "Indoor" },
       "temperature_after_heater_cooler": { "name": "Temperature after heater/cooler" },
       "gwc_temperature": { "name": "Ground heat exchanger temperature" },
       "room_temperature": { "name": "Room temperature" },

--- a/custom_components/reqnet/translations/pl.json
+++ b/custom_components/reqnet/translations/pl.json
@@ -44,7 +44,7 @@
           "manual_mode": "Tryb ręczny",
           "intelligent_mode": "Tryb inteligentny",
           "efficiency_measurement_mode": "Tryb pomiaru wydajności",
-          "unknown_mode": "Nieznany tryb"
+          "unknown_mode": "Nieznany tryb ({value})"
         }
       },
       "heating_cooling_status": {
@@ -53,7 +53,7 @@
           "inactive": "Nieaktywna",
           "heating": "Grzanie",
           "cooling": "Chłodzenie",
-          "unknown_status": "Nieznany status"
+          "unknown_status": "Nieznany status ({value})"
         }
       },
       "device_model": { "name": "Model urządzenia" },
@@ -76,7 +76,7 @@
           "open_manual": "Otwarty (ręcznie)",
           "closed_auto": "Zamknięty (auto)",
           "open_auto": "Otwarty (auto)",
-          "unknown_status": "Nieznany status"
+          "unknown_status": "Nieznany status ({value})"
         }
       },
       "error_code": { "name": "Kod błędu" },
@@ -103,7 +103,7 @@
         "state": {
           "left": "Lewy",
           "right": "Prawy",
-          "unknown": "Nieznany"
+          "unknown": "Nieznany ({value})"
         }
       },
       "overpressure_coefficient": { "name": "Współczynnik nadciśnienia" },

--- a/custom_components/reqnet/translations/pl.json
+++ b/custom_components/reqnet/translations/pl.json
@@ -1,0 +1,149 @@
+{
+  "config": {
+    "error": {
+      "cannot_connect": "Nie można połączyć z urządzeniem. Sprawdź host i spróbuj ponownie.",
+      "invalid_json": "Nieprawidłowa odpowiedź z urządzenia (nieprawidłowy JSON).",
+      "invalid_response": "Nieoczekiwana struktura odpowiedzi z urządzenia.",
+      "http_error": "Wystąpił błąd HTTP podczas komunikacji z urządzeniem.",
+      "unknown": "Wystąpił nieoczekiwany błąd."
+    }
+  },
+  "entity": {
+    "sensor": {
+      "device_status": {
+        "name": "Status urządzenia",
+        "state": {
+          "on": "Włączone",
+          "off": "Wyłączone"
+        }
+      },
+      "max_supply_flow": { "name": "Maksymalna wartość nawiewu" },
+      "current_temperature": { "name": "Aktualna temperatura" },
+      "current_supply_flow": { "name": "Aktualna wartość nawiewu" },
+      "current_extraction_flow": { "name": "Aktualna wartość wyciągu" },
+      "supply_manual_mode": { "name": "Nawiew tryb ręczny" },
+      "extraction_manual_mode": { "name": "Wyciąg tryb ręczny" },
+      "humidity": { "name": "Wilgotność" },
+      "co2_level": { "name": "Poziom CO2" },
+      "schedule_status": {
+        "name": "Status harmonogramu",
+        "state": {
+          "active": "Aktywny",
+          "inactive": "Nieaktywny"
+        }
+      },
+      "operation_mode": {
+        "name": "Tryb pracy",
+        "state": {
+          "fast_heating": "Szybkie grzanie",
+          "fast_cooling": "Szybkie chłodzenie",
+          "vacation": "Urlop",
+          "ventilation": "Przewietrzanie",
+          "purification": "Oczyszczanie",
+          "fireplace": "Kominek",
+          "manual_mode": "Tryb ręczny",
+          "intelligent_mode": "Tryb inteligentny",
+          "efficiency_measurement_mode": "Tryb pomiaru wydajności",
+          "unknown_mode": "Nieznany tryb"
+        }
+      },
+      "heating_cooling_status": {
+        "name": "Status grzanie/chłodzenie",
+        "state": {
+          "inactive": "Nieaktywna",
+          "heating": "Grzanie",
+          "cooling": "Chłodzenie",
+          "unknown_status": "Nieznany status"
+        }
+      },
+      "device_model": { "name": "Model urządzenia" },
+      "intake_temperature": { "name": "Temperatura na czerpni" },
+      "exhaust_duct_temperature": { "name": "Temperatura na wyrzutni" },
+      "supply_temperature": { "name": "Temperatura nawiewu" },
+      "extraction_temperature": { "name": "Temperatura wyciągu" },
+      "temperature_after_heater_cooler": { "name": "Temperatura za nagrzewnicą/chłodnicą" },
+      "gwc_temperature": { "name": "Temperatura GWC" },
+      "room_temperature": { "name": "Temperatura w pomieszczeniu" },
+      "additional_sensor_temperature": { "name": "Temperatura dodatkowego czujnika" },
+      "supply_duct_resistance": { "name": "Opór ciągu nawiewnego" },
+      "extraction_duct_resistance": { "name": "Opór ciągu wywiewnego" },
+      "supply_pressure": { "name": "Ciśnienie nawiew" },
+      "extraction_pressure": { "name": "Ciśnienie wyciąg" },
+      "bypass_status": {
+        "name": "Status By-passu",
+        "state": {
+          "closed_manual": "Zamknięty (ręcznie)",
+          "open_manual": "Otwarty (ręcznie)",
+          "closed_auto": "Zamknięty (auto)",
+          "open_auto": "Otwarty (auto)",
+          "unknown_status": "Nieznany status"
+        }
+      },
+      "error_code": { "name": "Kod błędu" },
+      "message_code": { "name": "Kod komunikatu" },
+      "humidity_detection": {
+        "name": "Detekcja wilgotności",
+        "state": {
+          "active": "Aktywna",
+          "inactive": "Nieaktywna"
+        }
+      },
+      "preheater_status": {
+        "name": "Status nagrzewnicy wstępnej",
+        "state": {
+          "active": "Aktywna",
+          "inactive": "Nieaktywna"
+        }
+      },
+      "antifreeze_system_status": { "name": "Status systemu antyzamrożeniowego" },
+      "condensation_system_status": { "name": "Status systemu przeciwwykropleniowego" },
+      "filter_days_until_replacement": { "name": "Dni do wymiany filtra" },
+      "mount_type": {
+        "name": "Typ montażu",
+        "state": {
+          "left": "Lewy",
+          "right": "Prawy",
+          "unknown": "Nieznany"
+        }
+      },
+      "overpressure_coefficient": { "name": "Współczynnik nadciśnienia" },
+      "supply_fan_speed": { "name": "Prędkość wentylatora nawiew" },
+      "extraction_fan_speed": { "name": "Prędkość wentylatora wyciąg" },
+      "supply_fan_power": { "name": "Moc wentylatora nawiewnego" },
+      "extraction_fan_power": { "name": "Moc wentylatora wywiewnego" },
+      "comfort_temperature_setpoint": { "name": "Ustawiona temperatura komfortu" },
+      "co2_sensitivity": { "name": "Aktualna czułość CO2" },
+      "higro_sensitivity": { "name": "Aktualna czułość HIGRO" },
+      "firmware_version_major": { "name": "Wersja firmware (major)" },
+      "firmware_version_build": { "name": "Wersja firmware (build)" },
+      "firmware_version_wifi": { "name": "Wersja firmware WiFi" }
+    },
+    "button": {
+      "automatic_mode": { "name": "Reqnet Włącz tryb inteligentny" },
+      "manual_mode": { "name": "Reqnet Włącz tryb ręczny" }
+    },
+    "binary_sensor": {
+      "device_status": { "name": "Rekuperator - Status urządzenia" }
+    }
+  },
+  "services": {
+    "set_manual_mode": {
+      "name": "Ustaw tryb ręczny",
+      "description": "Ustawia tryb ręczny z określonymi wartościami nawiewu i wyciągu",
+      "fields": {
+        "device_id": {
+          "name": "ID urządzenia",
+          "description": "ID urządzenia Reqnet (MAC address)"
+        },
+        "airflow_value": {
+          "name": "Wartość nawiewu",
+          "description": "Zadana wartość nawiewu (m³/h)"
+        },
+        "air_extraction_value": {
+          "name": "Wartość wyciągu",
+          "description": "Zadana wartość wyciągu (m³/h)"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Following the way Home Assistant handles translations I extracted (with the help of Cursor/Claude) the Polish strings into a translation file and also added an English translation file.

I am not sure if there are many people like me with a house with a ReqNet recuperator in Poland who do not speak Polish well and prefer Home Assistant in English. 